### PR TITLE
Rename single variable variants

### DIFF
--- a/source/components/button.scss
+++ b/source/components/button.scss
@@ -93,7 +93,7 @@
   // Disabled
 
   &:disabled {
-    color: $color-gray-medium-1;
+    color: $color-gray-medium;
 
     &:not([class*="plain"]) {
       background-color: $color-gray-light-2;

--- a/source/components/link.scss
+++ b/source/components/link.scss
@@ -12,7 +12,7 @@
 
   &:hover,
   &:focus {
-    border-width: $border-width-thick-1;
+    border-width: $border-width-thick;
   }
 
   // Plain

--- a/source/components/table.scss
+++ b/source/components/table.scss
@@ -15,8 +15,8 @@
     // Employ `calc()` to ensure precise alignment with items that use the same
     // spacing values but lack a border.
     padding: $space-small-1 $space-regular
-      calc(#{$space-small-1} - #{$border-width-thick-1});
-    border-bottom: $border-width-thick-1 solid $color-gray-light-3;
+      calc(#{$space-small-1} - #{$border-width-thick});
+    border-bottom: $border-width-thick solid $color-gray-light-3;
     text-align: left;
     vertical-align: top;
   }

--- a/source/components/tabset.scss
+++ b/source/components/tabset.scss
@@ -15,8 +15,8 @@
   &__tab {
     display: inline-block;
     padding: $space-small-2 $space-regular
-      calc(#{$space-small-2} - #{$border-width-thick-1}) $space-regular;
-    border-bottom: $border-width-thick-1 solid transparent;
+      calc(#{$space-small-2} - #{$border-width-thick}) $space-regular;
+    border-bottom: $border-width-thick solid transparent;
     // Negate parent bottom border.
     margin-bottom: -#{$border-width-regular};
     color: $color-gray-regular;

--- a/source/components/textfield.scss
+++ b/source/components/textfield.scss
@@ -9,7 +9,7 @@
   // spacing values but lack a border.
   padding: calc(#{$space-small-2} - #{$border-width-regular})
     calc(#{$space-regular} - #{$border-width-regular});
-  border: $border-width-regular solid $color-gray-medium-1;
+  border: $border-width-regular solid $color-gray-medium;
   border-radius: $border-radius-regular;
   font-size: $font-size-regular;
   line-height: $line-height-regular;
@@ -50,7 +50,7 @@
 
   &-label {
     &.is-disabled {
-      color: $color-gray-medium-1;
+      color: $color-gray-medium;
       cursor: not-allowed;
     }
   }

--- a/source/components/toggle.scss
+++ b/source/components/toggle.scss
@@ -5,7 +5,7 @@
 .c-toggle {
   width: 1.25rem;
   height: 1.25rem;
-  border: $border-width-regular solid $color-gray-medium-1;
+  border: $border-width-regular solid $color-gray-medium;
   border-radius: $border-radius-regular;
   vertical-align: middle;
   background-color: $color-white-regular;
@@ -59,7 +59,7 @@
     cursor: pointer;
 
     &.is-disabled {
-      color: $color-gray-medium-1;
+      color: $color-gray-medium;
       cursor: not-allowed;
     }
   }

--- a/source/settings/color.scss
+++ b/source/settings/color.scss
@@ -36,7 +36,7 @@ $color-gray-light-2: hsl(0, 0%, 92%);
 $color-gray-light-3: hsl(0, 0%, 88%);
 $color-gray-light-4: hsl(0, 0%, 84%);
 // Provide a medium gray color.
-$color-gray-medium-1: hsl(0, 0%, 60%);
+$color-gray-medium: hsl(0, 0%, 60%);
 // Provide a set of dark gray colors.
 $color-gray-dark-1: hsl(0, 0%, 16%);
 $color-gray-dark-2: hsl(0, 0%, 12%);

--- a/source/settings/decoration.scss
+++ b/source/settings/decoration.scss
@@ -7,7 +7,7 @@
 // Establish a standard border width.
 $border-width-regular: 1px;
 // Provide a thick border width.
-$border-width-thick-1: 2px;
+$border-width-thick: 2px;
 
 // Border radius
 


### PR DESCRIPTION
Appending a number at the end of a unique variable variant has no benefit and may create confusion when establishing a compact design system.