### PR TITLE
Clarify grid definition

### DIFF
--- a/source/helpers/grid.scss
+++ b/source/helpers/grid.scss
@@ -8,7 +8,7 @@
 
   @each $breakpoint-name, $grid-properties in $grid-definition {
     @include breakpoint($breakpoint-name) {
-      // Provide a breakpoint suffix only if the argument is a breakpoint name
+      // Provide a breakpoint prefix only if the argument is a breakpoint name
       // established via viewport settings.
       $breakpoint-prefix: if(
         $breakpoint-name != "default",

--- a/source/helpers/grid.scss
+++ b/source/helpers/grid.scss
@@ -8,6 +8,9 @@
 
   @each $breakpoint-name, $grid-properties in $grid-definition {
     @include breakpoint($breakpoint-name) {
+      // Establish a grid namespace. Remove the period from the parent selector
+      // so that the resulting string can be used inside class names.
+      $grid-namespace: str-slice(#{&}, 2);
       // Provide a breakpoint prefix only if the argument is a breakpoint name
       // established via viewport settings.
       $breakpoint-prefix: if(
@@ -22,7 +25,7 @@
       grid-gap: $gap-size;
 
       @for $i from 1 through $column-count {
-        @at-root .#{$breakpoint-prefix}grid__column-#{$i} {
+        @at-root .#{$breakpoint-prefix}#{$grid-namespace}__column-#{$i} {
           grid-column: span #{$i};
         }
       }

--- a/source/helpers/grid.scss
+++ b/source/helpers/grid.scss
@@ -3,38 +3,29 @@
 // -----------------------------------------------------------------------------
 
 // Use as argument a grid definition established via layout settings.
-@mixin grid($definition) {
+@mixin grid($grid-definition) {
   display: grid;
 
-  @each $breakpoint-name, $column-count, $gap-size in $definition {
-    // Generate grid properties only if the column count and gap size have valid
-    // values.
-    @if (
-      type-of($column-count) == number and
-      unitless($column-count) == true and
-      type-of($gap-size) == number and
-      unitless($gap-size) == false
-    ) {
-      @include breakpoint($breakpoint-name) {
-        // Provide a breakpoint suffix only if the argument is a breakpoint name
-        // established via viewport settings.
-        $breakpoint-prefix: if(
-          $breakpoint-name != "default",
-          #{$breakpoint-name}\:,
-          null
-        );
+  @each $breakpoint-name, $grid-properties in $grid-definition {
+    @include breakpoint($breakpoint-name) {
+      // Provide a breakpoint suffix only if the argument is a breakpoint name
+      // established via viewport settings.
+      $breakpoint-prefix: if(
+        $breakpoint-name != "default",
+        #{$breakpoint-name}\:,
+        null
+      );
+      $column-count: nth($grid-properties, 1);
+      $gap-size: nth($grid-properties, 2);
 
-        grid-template-columns: repeat($column-count, 1fr);
-        grid-gap: $gap-size;
+      grid-template-columns: repeat($column-count, 1fr);
+      grid-gap: $gap-size;
 
-        @for $i from 1 through $column-count {
-          @at-root .#{$breakpoint-prefix}grid__column-#{$i} {
-            grid-column: span #{$i};
-          }
+      @for $i from 1 through $column-count {
+        @at-root .#{$breakpoint-prefix}grid__column-#{$i} {
+          grid-column: span #{$i};
         }
       }
-    } @else {
-      @error "Invalid number of columns or gap size. Check spelling or review layout settings.";
     }
   }
 }

--- a/source/settings/layout.scss
+++ b/source/settings/layout.scss
@@ -15,7 +15,7 @@ $content-max-width: 1240px;
 // are intended for small screens although the classes they help generate will
 // work across all viewport sizes.
 $grid-regular: (
-  default 2 1.25rem,
-  medium 6 1.25rem,
-  large 12 2.5rem
+  default: (2, 1.25rem),
+  medium: (6, 1.25rem),
+  large: (12, 2.5rem)
 );


### PR DESCRIPTION
Breakpoint names are best used as keys in a grid definition map in order to establish a setting that is easier to understand.