### PR TITLE
Use Sass modules

### DIFF
--- a/source/basics/reset.scss
+++ b/source/basics/reset.scss
@@ -3,8 +3,7 @@
 // inconsistencies.
 // -----------------------------------------------------------------------------
 
-@use "../settings/color" as *;
-@use "../settings/typography" as *;
+@use "../settings" as *;
 
 // Universal
 

--- a/source/basics/reset.scss
+++ b/source/basics/reset.scss
@@ -3,6 +3,9 @@
 // inconsistencies.
 // -----------------------------------------------------------------------------
 
+@use "../settings/color" as *;
+@use "../settings/typography" as *;
+
 // Universal
 
 // Change box model on all elements and pseudo-elements so that their width and

--- a/source/components/button.scss
+++ b/source/components/button.scss
@@ -2,6 +2,11 @@
 // Perform clearly defined actions.
 // -----------------------------------------------------------------------------
 
+@use "../settings/color" as *;
+@use "../settings/decoration" as *;
+@use "../settings/spacing" as *;
+@use "../settings/typography" as *;
+
 .button {
   display: inline-block;
   padding: $space-small-2 $space-regular;

--- a/source/components/button.scss
+++ b/source/components/button.scss
@@ -2,10 +2,7 @@
 // Perform clearly defined actions.
 // -----------------------------------------------------------------------------
 
-@use "../settings/color" as *;
-@use "../settings/decoration" as *;
-@use "../settings/spacing" as *;
-@use "../settings/typography" as *;
+@use "../settings" as *;
 
 .button {
   display: inline-block;

--- a/source/components/card.scss
+++ b/source/components/card.scss
@@ -2,6 +2,11 @@
 // Group content and actions related to a single topic.
 // -----------------------------------------------------------------------------
 
+@use "../settings/color" as *;
+@use "../settings/decoration" as *;
+@use "../settings/spacing" as *;
+@use "../settings/typography" as *;
+
 .card {
   display: block;
   // Employ `calc()` to ensure precise alignment with items that use the same

--- a/source/components/card.scss
+++ b/source/components/card.scss
@@ -2,10 +2,7 @@
 // Group content and actions related to a single topic.
 // -----------------------------------------------------------------------------
 
-@use "../settings/color" as *;
-@use "../settings/decoration" as *;
-@use "../settings/spacing" as *;
-@use "../settings/typography" as *;
+@use "../settings" as *;
 
 .card {
   display: block;

--- a/source/components/container.scss
+++ b/source/components/container.scss
@@ -2,9 +2,8 @@
 // Lay out high-level content units.
 // -----------------------------------------------------------------------------
 
-@use "../settings/layout" as *;
-@use "../settings/spacing" as *;
-@use "../helpers/breakpoint" as *;
+@use "../settings" as *;
+@use "../helpers" as *;
 
 .container {
   max-width: $content-max-width;

--- a/source/components/container.scss
+++ b/source/components/container.scss
@@ -2,6 +2,10 @@
 // Lay out high-level content units.
 // -----------------------------------------------------------------------------
 
+@use "../settings/layout" as *;
+@use "../settings/spacing" as *;
+@use "../helpers/breakpoint" as *;
+
 .container {
   max-width: $content-max-width;
   padding-right: $space-large-6;

--- a/source/components/grid.scss
+++ b/source/components/grid.scss
@@ -2,8 +2,8 @@
 // Arrange and size items using a two-dimensional layout system.
 // -----------------------------------------------------------------------------
 
-@use "../settings/layout" as *;
-@use "../helpers/grid" as *;
+@use "../settings" as *;
+@use "../helpers" as *;
 
 .grid {
   @include grid($grid-regular);

--- a/source/components/grid.scss
+++ b/source/components/grid.scss
@@ -2,6 +2,9 @@
 // Arrange and size items using a two-dimensional layout system.
 // -----------------------------------------------------------------------------
 
+@use "../settings/layout" as *;
+@use "../helpers/grid" as *;
+
 .grid {
   @include grid($grid-regular);
 }

--- a/source/components/heading.scss
+++ b/source/components/heading.scss
@@ -2,8 +2,7 @@
 // Title content units.
 // -----------------------------------------------------------------------------
 
-@use "../settings/spacing" as *;
-@use "../settings/typography" as *;
+@use "../settings" as *;
 
 .heading-1 {
   margin-bottom: $space-large-4;

--- a/source/components/heading.scss
+++ b/source/components/heading.scss
@@ -2,6 +2,9 @@
 // Title content units.
 // -----------------------------------------------------------------------------
 
+@use "../settings/spacing" as *;
+@use "../settings/typography" as *;
+
 .heading-1 {
   margin-bottom: $space-large-4;
   font-size: $font-size-large-1;

--- a/source/components/lead.scss
+++ b/source/components/lead.scss
@@ -2,8 +2,7 @@
 // Emphasize significant text fragments.
 // -----------------------------------------------------------------------------
 
-@use "../settings/spacing" as *;
-@use "../settings/typography" as *;
+@use "../settings" as *;
 
 .lead {
   margin-bottom: $space-large-5;

--- a/source/components/lead.scss
+++ b/source/components/lead.scss
@@ -2,6 +2,9 @@
 // Emphasize significant text fragments.
 // -----------------------------------------------------------------------------
 
+@use "../settings/spacing" as *;
+@use "../settings/typography" as *;
+
 .lead {
   margin-bottom: $space-large-5;
   font-size: $font-size-large-3;

--- a/source/components/link.scss
+++ b/source/components/link.scss
@@ -2,6 +2,9 @@
 // Reference new content.
 // -----------------------------------------------------------------------------
 
+@use "../settings/color" as *;
+@use "../settings/decoration" as *;
+
 .link {
   // Distance bottom border from descenders.
   padding-bottom: 0.0625em;

--- a/source/components/link.scss
+++ b/source/components/link.scss
@@ -2,8 +2,7 @@
 // Reference new content.
 // -----------------------------------------------------------------------------
 
-@use "../settings/color" as *;
-@use "../settings/decoration" as *;
+@use "../settings" as *;
 
 .link {
   // Distance bottom border from descenders.

--- a/source/components/list.scss
+++ b/source/components/list.scss
@@ -2,6 +2,8 @@
 // Present related items in a continuous format.
 // -----------------------------------------------------------------------------
 
+@use "../settings/spacing" as *;
+
 .list {
   display: flex;
   flex-direction: column;

--- a/source/components/list.scss
+++ b/source/components/list.scss
@@ -2,7 +2,7 @@
 // Present related items in a continuous format.
 // -----------------------------------------------------------------------------
 
-@use "../settings/spacing" as *;
+@use "../settings" as *;
 
 .list {
   display: flex;

--- a/source/components/nav.scss
+++ b/source/components/nav.scss
@@ -2,6 +2,9 @@
 // Display major navigation links or key actions.
 // -----------------------------------------------------------------------------
 
+@use "../settings/color" as *;
+@use "../settings/spacing" as *;
+
 .nav {
   display: flex;
   flex-wrap: wrap;

--- a/source/components/nav.scss
+++ b/source/components/nav.scss
@@ -2,8 +2,7 @@
 // Display major navigation links or key actions.
 // -----------------------------------------------------------------------------
 
-@use "../settings/color" as *;
-@use "../settings/spacing" as *;
+@use "../settings" as *;
 
 .nav {
   display: flex;

--- a/source/components/notice.scss
+++ b/source/components/notice.scss
@@ -2,6 +2,10 @@
 // Provide feedback or additional information.
 // -----------------------------------------------------------------------------
 
+@use "../settings/color" as *;
+@use "../settings/decoration" as *;
+@use "../settings/spacing" as *;
+
 .notice {
   padding: $space-regular $space-large-5;
   border-radius: $border-radius-regular;

--- a/source/components/notice.scss
+++ b/source/components/notice.scss
@@ -2,9 +2,7 @@
 // Provide feedback or additional information.
 // -----------------------------------------------------------------------------
 
-@use "../settings/color" as *;
-@use "../settings/decoration" as *;
-@use "../settings/spacing" as *;
+@use "../settings" as *;
 
 .notice {
   padding: $space-regular $space-large-5;

--- a/source/components/segment.scss
+++ b/source/components/segment.scss
@@ -2,6 +2,9 @@
 // Separate content units.
 // -----------------------------------------------------------------------------
 
+@use "../settings/spacing" as *;
+@use "../helpers/breakpoint" as *;
+
 .segment {
   padding-top: $space-large-2;
   padding-bottom: $space-large-2;

--- a/source/components/segment.scss
+++ b/source/components/segment.scss
@@ -2,8 +2,8 @@
 // Separate content units.
 // -----------------------------------------------------------------------------
 
-@use "../settings/spacing" as *;
-@use "../helpers/breakpoint" as *;
+@use "../settings" as *;
+@use "../helpers" as *;
 
 .segment {
   padding-top: $space-large-2;

--- a/source/components/table.scss
+++ b/source/components/table.scss
@@ -2,6 +2,11 @@
 // Display data in rows and columns.
 // -----------------------------------------------------------------------------
 
+@use "../settings/color" as *;
+@use "../settings/decoration" as *;
+@use "../settings/spacing" as *;
+@use "../settings/typography" as *;
+
 .table {
   width: 100%;
 

--- a/source/components/table.scss
+++ b/source/components/table.scss
@@ -2,10 +2,7 @@
 // Display data in rows and columns.
 // -----------------------------------------------------------------------------
 
-@use "../settings/color" as *;
-@use "../settings/decoration" as *;
-@use "../settings/spacing" as *;
-@use "../settings/typography" as *;
+@use "../settings" as *;
 
 .table {
   width: 100%;

--- a/source/components/textfield.scss
+++ b/source/components/textfield.scss
@@ -2,6 +2,11 @@
 // Input and edit text.
 // -----------------------------------------------------------------------------
 
+@use "../settings/color" as *;
+@use "../settings/decoration" as *;
+@use "../settings/spacing" as *;
+@use "../settings/typography" as *;
+
 .textfield {
   display: block;
   width: 100%;

--- a/source/components/textfield.scss
+++ b/source/components/textfield.scss
@@ -2,10 +2,7 @@
 // Input and edit text.
 // -----------------------------------------------------------------------------
 
-@use "../settings/color" as *;
-@use "../settings/decoration" as *;
-@use "../settings/spacing" as *;
-@use "../settings/typography" as *;
+@use "../settings" as *;
 
 .textfield {
   display: block;

--- a/source/components/toggle.scss
+++ b/source/components/toggle.scss
@@ -2,9 +2,7 @@
 // Alternate between states on one or more options.
 // -----------------------------------------------------------------------------
 
-@use "../settings/color" as *;
-@use "../settings/decoration" as *;
-@use "../settings/spacing" as *;
+@use "../settings" as *;
 
 .toggle {
   width: 1.25rem;

--- a/source/components/toggle.scss
+++ b/source/components/toggle.scss
@@ -2,6 +2,10 @@
 // Alternate between states on one or more options.
 // -----------------------------------------------------------------------------
 
+@use "../settings/color" as *;
+@use "../settings/decoration" as *;
+@use "../settings/spacing" as *;
+
 .toggle {
   width: 1.25rem;
   height: 1.25rem;

--- a/source/helpers/breakpoint.scss
+++ b/source/helpers/breakpoint.scss
@@ -2,6 +2,8 @@
 // Generate necessary content blocks.
 // -----------------------------------------------------------------------------
 
+@use "../settings/viewport" as *;
+
 // Use as argument a keyword or a breakpoint name established via viewport
 // settings.
 @mixin breakpoint($breakpoint-name) {

--- a/source/helpers/breakpoint.scss
+++ b/source/helpers/breakpoint.scss
@@ -2,7 +2,7 @@
 // Generate necessary content blocks.
 // -----------------------------------------------------------------------------
 
-@use "../settings/viewport" as *;
+@use "../settings" as *;
 
 // Use as argument a keyword or a breakpoint name established via viewport
 // settings.

--- a/source/helpers/grid.scss
+++ b/source/helpers/grid.scss
@@ -2,6 +2,10 @@
 // Generate bespoke grids.
 // -----------------------------------------------------------------------------
 
+@use "../settings/layout" as *;
+@use "../settings/viewport" as *;
+@use "../helpers/breakpoint" as *;
+
 // Use as argument a grid definition established via layout settings.
 @mixin grid($grid-definition) {
   display: grid;

--- a/source/helpers/grid.scss
+++ b/source/helpers/grid.scss
@@ -2,8 +2,7 @@
 // Generate bespoke grids.
 // -----------------------------------------------------------------------------
 
-@use "../settings/layout" as *;
-@use "../settings/viewport" as *;
+@use "../settings" as *;
 @use "../helpers/breakpoint" as *;
 
 // Use as argument a grid definition established via layout settings.

--- a/source/helpers/index.scss
+++ b/source/helpers/index.scss
@@ -1,0 +1,6 @@
+// HELPERS
+// Provide ways to carry out recurring tasks.
+// -----------------------------------------------------------------------------
+
+@forward "breakpoint";
+@forward "grid";

--- a/source/settings/index.scss
+++ b/source/settings/index.scss
@@ -1,0 +1,10 @@
+// SETTINGS
+// Manage global configuration options.
+// -----------------------------------------------------------------------------
+
+@forward "color";
+@forward "decoration";
+@forward "layout";
+@forward "spacing";
+@forward "typography";
+@forward "viewport";

--- a/source/spark.scss
+++ b/source/spark.scss
@@ -1,50 +1,32 @@
-// SETTINGS
-// Manage global configuration options.
-// -----------------------------------------------------------------------------
-
-@import "settings/color";
-@import "settings/decoration";
-@import "settings/layout";
-@import "settings/spacing";
-@import "settings/typography";
-@import "settings/viewport";
-
-// HELPERS
-// Provide ways to carry out recurring tasks.
-// -----------------------------------------------------------------------------
-
-@import "helpers/breakpoint";
-@import "helpers/grid";
-
 // BASICS
 // Establish defaults for fundamental items.
 // -----------------------------------------------------------------------------
 
-@import "basics/reset";
+@use "basics/reset";
 
 // COMPONENTS
 // Define independent, reusable items.
 // -----------------------------------------------------------------------------
 
-@import "components/button";
-@import "components/card";
-@import "components/container";
-@import "components/grid";
-@import "components/heading";
-@import "components/lead";
-@import "components/link";
-@import "components/list";
-@import "components/nav";
-@import "components/notice";
-@import "components/segment";
-@import "components/table";
-@import "components/textfield";
-@import "components/toggle";
+@use "components/button";
+@use "components/card";
+@use "components/container";
+@use "components/grid";
+@use "components/heading";
+@use "components/lead";
+@use "components/link";
+@use "components/list";
+@use "components/nav";
+@use "components/notice";
+@use "components/segment";
+@use "components/table";
+@use "components/textfield";
+@use "components/toggle";
 
 // UTILITIES
 // Identify generic functional traits.
 // -----------------------------------------------------------------------------
 
-@import "utilities/display";
-@import "utilities/margin";
-@import "utilities/text";
+@use "utilities/display";
+@use "utilities/margin";
+@use "utilities/text";

--- a/source/utilities/margin.scss
+++ b/source/utilities/margin.scss
@@ -2,6 +2,9 @@
 // Designate available margins.
 // -----------------------------------------------------------------------------
 
+@use "../settings/spacing" as *;
+@use "../helpers/breakpoint" as *;
+
 // Right
 
 .margin-right-regular {

--- a/source/utilities/margin.scss
+++ b/source/utilities/margin.scss
@@ -2,8 +2,8 @@
 // Designate available margins.
 // -----------------------------------------------------------------------------
 
-@use "../settings/spacing" as *;
-@use "../helpers/breakpoint" as *;
+@use "../settings" as *;
+@use "../helpers" as *;
 
 // Right
 


### PR DESCRIPTION
Over the next few years, `@import` will be deprecated in favor of `@use` and `@forward`. Spark aims to provide a modern starting point so the new rules should be employed. Furthermore, modules ensure a cleaner global namespace.