### PR TITLE
Rename full border radius setting

### DIFF
--- a/source/components/radio.scss
+++ b/source/components/radio.scss
@@ -6,7 +6,7 @@
   width: 1.25rem;
   height: 1.25rem;
   border: $border-width-regular solid $color-neutral-medium;
-  border-radius: $border-radius-full;
+  border-radius: $border-radius-whole;
   vertical-align: middle;
   background-color: $color-neutral-white;
   cursor: pointer;

--- a/source/settings/decoration.scss
+++ b/source/settings/decoration.scss
@@ -14,4 +14,4 @@ $border-width-thick: 2px;
 // Establish a standard border radius.
 $border-radius-regular: 4px;
 // Provide a border radius that produces fully rounded corners.
-$border-radius-full: 720px;
+$border-radius-whole: 720px;


### PR DESCRIPTION
The "whole" label seems more appropriate when establishing such values.