### PR TITLE
Remove unused space setting

### DIFF
--- a/source/settings/spacing.scss
+++ b/source/settings/spacing.scss
@@ -18,4 +18,3 @@ $space-small-1: 0.75rem;
 $space-small-2: 0.625rem;
 $space-small-3: 0.5rem;
 $space-small-4: 0.375rem;
-$space-small-5: 0.25rem;


### PR DESCRIPTION
The smallest space setting is no longer necessary because the item that employed it has been removed.