### PR TITLE
Update framework version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spark-vanilla",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A minimal starting point for developing effective web-based interfaces.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The framework version number should be updated on the hotfix or release branches. This did not happen with the previous hotfix.