### PR TITLE
Rephrase breakpoint helper error message

### DIFF
--- a/source/helpers/set-breakpoint.scss
+++ b/source/helpers/set-breakpoint.scss
@@ -12,6 +12,6 @@
       @content;
     }
   } @else {
-    @error "Invalid breakpoint name. Check spelling or review breakpoints established via viewport settings.";
+    @error "Invalid breakpoint name. Check spelling or review breakpoints viewport settings.";
   }
 }


### PR DESCRIPTION
Match the error message displayed for the same helper by the Lode (formerly known as Ignition) framework.