### PR TITLE
Revise checked state background icons

### DIFF
--- a/build/main.css
+++ b/build/main.css
@@ -328,8 +328,9 @@ summary {
 }
 .checkbox:checked {
   border-color: #1060bc;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><path d='M2.91421 6.58579L1.5 8L6.44975 12.9497L14.935 4.46447L13.5208 3.05025L6.44975 10.1213L2.91421 6.58579Z' fill='%23fff'/></svg>");
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M2.91421 6.58579L1.5 8L6.44975 12.9497L14.935 4.46447L13.5208 3.05025L6.44975 10.1213L2.91421 6.58579Z' fill='%23fff'/></svg>");
   background-position: center;
+  background-size: 1rem;
   background-repeat: no-repeat;
   background-color: #1060bc;
 }
@@ -515,8 +516,9 @@ summary {
 }
 .radio:checked {
   border-color: #1060bc;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><circle cx='8' cy='8' r='5' fill='%23fff'/></svg>");
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><circle cx='8' cy='8' r='5' fill='%23fff'/></svg>");
   background-position: center;
+  background-size: 1rem;
   background-repeat: no-repeat;
   background-color: #1060bc;
 }

--- a/source/components/checkbox.scss
+++ b/source/components/checkbox.scss
@@ -15,8 +15,9 @@
 
   &:checked {
     border-color: $color-brand-regular;
-    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><path d='M2.91421 6.58579L1.5 8L6.44975 12.9497L14.935 4.46447L13.5208 3.05025L6.44975 10.1213L2.91421 6.58579Z' fill='%23fff'/></svg>");
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='M2.91421 6.58579L1.5 8L6.44975 12.9497L14.935 4.46447L13.5208 3.05025L6.44975 10.1213L2.91421 6.58579Z' fill='%23fff'/></svg>");
     background-position: center;
+    background-size: 1rem;
     background-repeat: no-repeat;
     background-color: $color-brand-regular;
   }

--- a/source/components/radio.scss
+++ b/source/components/radio.scss
@@ -15,8 +15,9 @@
 
   &:checked {
     border-color: $color-brand-regular;
-    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><circle cx='8' cy='8' r='5' fill='%23fff'/></svg>");
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><circle cx='8' cy='8' r='5' fill='%23fff'/></svg>");
     background-position: center;
+    background-size: 1rem;
     background-repeat: no-repeat;
     background-color: $color-brand-regular;
   }


### PR DESCRIPTION
Avoid setting icon width and height via HTML attributes in order to ensure all presentational properties are stored inside stylesheets.